### PR TITLE
Fix start-indy.py to copy_missed promote rule-sets

### DIFF
--- a/indy/start-indy.py
+++ b/indy/start-indy.py
@@ -198,7 +198,7 @@ if os.path.isdir(INDY_DATA_PROMOTE):
 
 # copy_over("/usr/share/indy/promote", INDY_DATA_PROMOTE)
 # copy_over("/usr/share/indy/scripts", os.path.join(INDY_DATA, "scripts"))
-copy_over("/opt/indy/etc/indy/promote", INDY_DATA_PROMOTE)
+copy_missed("/opt/indy/etc/indy/promote", INDY_DATA_PROMOTE)
 copy_over("/opt/indy/etc/indy/scripts", os.path.join(INDY_DATA, "scripts"))
 copy_over("/opt/indy/etc/indy/lifecycle", os.path.join(INDY_DATA, "lifecycle"))
 


### PR DESCRIPTION
For new indy image, seems we will use burn-in promote rules instead of existed rules in storage, but the copy_over will overwrite the burn-in ones by existed ones. So here we should use copy_missed.