### PR TITLE
Add copy back of promote from /usr/share to /opt/indy

### DIFF
--- a/indy/start-indy.py
+++ b/indy/start-indy.py
@@ -199,6 +199,7 @@ if os.path.isdir(INDY_DATA_PROMOTE):
 # copy_over("/usr/share/indy/promote", INDY_DATA_PROMOTE)
 # copy_over("/usr/share/indy/scripts", os.path.join(INDY_DATA, "scripts"))
 copy_missed("/opt/indy/etc/indy/promote", INDY_DATA_PROMOTE)
+copy_missed("/usr/share/indy/data/promote", INDY_DATA_PROMOTE)
 copy_over("/opt/indy/etc/indy/scripts", os.path.join(INDY_DATA, "scripts"))
 copy_over("/opt/indy/etc/indy/lifecycle", os.path.join(INDY_DATA, "lifecycle"))
 


### PR DESCRIPTION
Seems that the /opt/indy/var/lib/indy mount volumn overwrite default docker created one, which cause the burn-in rules disapeared after start up. So added the copy back operation in start-indy.py from /usr/share to $indy_data