### PR TITLE
Add dynamic user configuration to image.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 .venv
 *.egg-info
 *.pyc
+*~

--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -19,7 +19,17 @@ RUN	mkdir -p /usr/share/indy && \
 
 RUN chmod +x /usr/local/bin/*
 
-ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/start-indy.py"]
+ADD setup-user.sh /usr/local/bin/setup-user.sh
+ADD passwd.template /opt/passwd.template
+
+RUN wget -P /tmp http://mirror.centos.org/centos/7.7.1908/os/x86_64/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /tmp/RPM-GPG-KEY-CentOS-7 && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum update -y --security && yum install -y nss_wrapper gettext && \
+    yum clean all && rm -rf /var/cache/yum
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+CMD ["bash", "-c", "/usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
 
 RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy
 RUN chmod -R 777 /etc/indy && chmod -R 777 /var/log/indy && chmod -R 777 /usr/share/indy
@@ -40,6 +50,7 @@ RUN chgrp -R 0 /opt && \
     chgrp -R 0 /var/log/indy && \
     chmod -R g=u /var/log/indy && \
     chgrp -R 0 /usr/share/indy && \
-    chmod -R g=u /usr/share/indy
+    chmod -R g=u /usr/share/indy && \
+    useradd indy --uid 1001 --gid 0
 
 USER 1001

--- a/indy/passwd.template
+++ b/indy/passwd.template
@@ -1,0 +1,16 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
+dbus:x:81:81:System message bus:/:/sbin/nologin
+indy:x:${USER_ID}:${GROUP_ID}::/home/indy:/bin/bash

--- a/indy/setup-user.sh
+++ b/indy/setup-user.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# configure dynamic user for containers in Openshift 
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < /opt/passwd.template > /tmp/passwd
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=/tmp/passwd
+export NSS_WRAPPER_GROUP=/etc/group
+cp /tmp/passwd /etc/passwd


### PR DESCRIPTION
 This PR solves the issue #21 
 This PR looks to add nss_wrapper module to the image. Allowing Openshift to add a user with a dynamic id and the image still recognizing the Dockerfile selected user.
 This is done by re-writing the passwd file with the id. A template passwd file is included and added to the image. This is populated at runtime with the new id of the user.

The call to dumb-init has been updated to call the setup-user.sh bash script before starting the jvm process. Using the technique to call additional bash scripts documented in the dumb-init repository.
