### PR TITLE
Fix 404 Not Found

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod +x /usr/local/bin/*
 ADD setup-user.sh /usr/local/bin/setup-user.sh
 ADD passwd.template /opt/passwd.template
 
-RUN wget -P /tmp http://mirror.centos.org/centos/7.7.1908/os/x86_64/RPM-GPG-KEY-CentOS-7 && \
+RUN wget -P /tmp http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7 && \
     rpm --import /tmp/RPM-GPG-KEY-CentOS-7 && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum update -y --security && yum install -y nss_wrapper gettext && \


### PR DESCRIPTION
Indy Jenkins build failed due to:
[logs:build/indy-binary-master-build-155] [91m--2020-06-02 00:52:33--  http://mirror.centos.org/centos/7.7.1908/os/x86_64/RPM-GPG-KEY-CentOS-7
[logs:build/indy-binary-master-build-155] [0m[91m2020-06-02 00:52:33 ERROR 404: Not Found.

The URL in question is deprecated. I update it to /7/.