### PR TITLE
disable set-user.sh which causes permission denied

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -29,7 +29,12 @@ RUN wget -P /tmp http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-
     yum clean all && rm -rf /var/cache/yum
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
-CMD ["bash", "-c", "/usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
+CMD ["bash", "-c", "/usr/local/bin/start-indy.py"]
+
+
+# [jdcasey] This results in: **bash: /usr/local/bin/setup-user.sh: Permission denied**
+#CMD ["bash", "-c", "/usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
+
 
 RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy
 RUN chmod -R 777 /etc/indy && chmod -R 777 /var/log/indy && chmod -R 777 /usr/share/indy


### PR DESCRIPTION
@whitingjr  you might want to have a look at this.

I think the underlying cause is that the Dockerfile sets the user to 1001, but the
startup command for the container includes set-user.sh, which copies the /etc/passwd
file into place from a filtered template.

I don't see how this could be Openshift-compatible, since the image would have to start
as the root user in order to have these kinds of permissions.

See also: MMENG-431