### PR TITLE
Remove cp command that overwrites passwd.

### DIFF
--- a/indy/setup-user.sh
+++ b/indy/setup-user.sh
@@ -6,4 +6,3 @@ envsubst < /opt/passwd.template > /tmp/passwd
 export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
 export NSS_WRAPPER_PASSWD=/tmp/passwd
 export NSS_WRAPPER_GROUP=/etc/group
-cp /tmp/passwd /etc/passwd


### PR DESCRIPTION
 The command that copies over the /etc/passwd file should not be necessary. Using the [documentation](https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#clipboard-5) as a reference here.