### PR TITLE
Switch out use of setup-user.sh in startup sequence.

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -30,8 +30,10 @@ RUN wget -P /tmp http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
-#CMD ["bash", "-c", "/usr/local/bin/start-indy.py"]
-CMD ["bash", "-c", "/usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
+# [jdcasey] This results in: **bash: /usr/local/bin/setup-user.sh: Permission denied**
+#CMD ["bash", "-c", "/usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
+CMD ["bash", "-c", "/usr/local/bin/start-indy.py"]
+
 
 
 RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy


### PR DESCRIPTION
 This is the first change to disable setup-user.sh script.