### PR TITLE
Add Dynamic User Support for Openshift.

### DIFF
--- a/indy/.bashrc
+++ b/indy/.bashrc
@@ -1,0 +1,14 @@
+# .bashrc
+
+# User specific aliases and functions
+
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+source /usr/local/bin/setup-user.sh
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+ . /etc/bashrc
+fi

--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -7,23 +7,36 @@ EXPOSE 8080 8081 8000
 USER root
 
 ADD start-indy.py /usr/local/bin/start-indy.py
+ADD setup-user.sh /usr/local/bin/setup-user.sh
+ADD setup-user.sh /etc/profile.d/setup-user.sh
+ADD passwd.template /opt/passwd.template
 
 ADD $tarball_url /tmp/indy-launcher.tar.gz
 RUN	tar -zxf /tmp/indy-launcher.tar.gz -C /opt
 
 ADD $data_tarball_url /tmp/indy-launcher-data.tar.gz
-RUN	mkdir -p /usr/share/indy && \
+RUN	mkdir -p /usr/share/indy /home/indy && \
 	tar -zxf /tmp/indy-launcher-data.tar.gz -C /usr/share/indy && \
 	mkdir -p /opt/indy/var/lib/indy/data/promote && \
 	cp -rf /usr/share/indy/data/promote/rules /opt/indy/var/lib/indy/data/promote/rules
 
 RUN chmod +x /usr/local/bin/*
 
-ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/start-indy.py"]
+# Openshift and dynamic user id. https://access.redhat.com/articles/4859371 integration
+# enabled by configuring Bourne shell user profile to call setup-user.sh script.
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+CMD ["bash", "-c", "source /usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
 
 RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy
 RUN chmod -R 777 /etc/indy && chmod -R 777 /var/log/indy && chmod -R 777 /usr/share/indy
 RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui
+RUN wget -P /tmp http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /tmp/RPM-GPG-KEY-CentOS-7 && \
+    yum-config-manager --add-repo http://mirror.centos.org/centos/7/os/x86_64/ && \
+    yum install -y gettext && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum install -y nss_wrapper && \
+    yum clean all && rm -rf /var/cache/yum /tmp/yum.log /tmp/RPM-GPG-KEY-CentOS-7
 
 ADD lowOverhead.jfc /usr/share/indy/flightrecorder.jfc
 
@@ -40,6 +53,14 @@ RUN chgrp -R 0 /opt && \
     chgrp -R 0 /var/log/indy && \
     chmod -R g=u /var/log/indy && \
     chgrp -R 0 /usr/share/indy && \
-    chmod -R g=u /usr/share/indy
+    chmod -R g=u /usr/share/indy && \
+    chgrp -R 0 /home/indy && \
+    chmod -R g=u /home/indy && \
+    chown -R 1001:0 /home/indy && \
+    chmod 644 /etc/profile.d/setup-user.sh
 
 USER 1001
+
+ENV LOGNAME=indy
+ENV USER=indy
+ENV HOME=/home/indy

--- a/indy/passwd.template
+++ b/indy/passwd.template
@@ -1,0 +1,17 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
+dbus:x:81:81:System message bus:/:/sbin/nologin
+indy:x:${USER_ID}:${GROUP_ID}:Indy Application User:${HOME}:/bin/bash
+

--- a/indy/setup-user.sh
+++ b/indy/setup-user.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Generate passwd file based on dynamic user for containers in Openshift and use NSS_WRAPPER to set it."
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < /opt/passwd.template > $HOME/passwd
+chmod 744 $HOME/passwd
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=$HOME/passwd
+export NSS_WRAPPER_GROUP=/etc/group
+echo "NSS_WRAPPER configured. Now running diagnostic commands to reveal nss_wrapper operating as expected."
+echo "id:$(id)"
+echo "whoami:$(whoami)"


### PR DESCRIPTION
 This PR looks to implement the integration of the Indy container image with Openshift. To solve issue #21 

 After integrating the Indy process will display this in the logs at the beginning.

```
Generate passwd file based on dynamic user for containers in Openshift and use NSS_WRAPPER to set it.
NSS_WRAPPER configured. Now running diagnostic commands to reveal nss_wrapper operating as expected.
id:uid=1013040000(indy) gid=0(root) groups=0(root),1013040000
whoami:indy
Read indy cli opts: 
Backup new promote /tmp/indy/promote
Copy new file: /opt/indy/etc/indy/promote/rule-sets/..2020_09_11_13_06_12.261534700/shared-imports.json
Copy new file: /opt/indy/etc/indy/promote/rule-sets/..2020_09_11_13_06_12.261534700/temporary-builds.json
Copy new file: /opt/indy/etc/indy/promote/rule-sets/..2020_09_11_13_06_12.261534700/pnc-builds.json
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/npm-no-pre-existing-paths.groovy
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/npm-parsable-package-meta.groovy
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/npm-version-pattern.groovy
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/parsable-pom.groovy
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/project-version-pattern.groovy
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/no-pre-existing-paths.groovy
Copy new file: /opt/indy/etc/indy/promote/rules/..2020_09_11_13_06_12.345731070/no-snapshot-paths.groovy
rm -r /opt/indy/etc/indy/scripts /opt/indy/var/lib/indy/data/scripts
cp -r /opt/indy/etc/indy/scripts /opt/indy/var/lib/indy/data/scripts
Command parts: ['/bin/bash', '-l', '/opt/indy/bin/indy.sh']
Generate passwd file based on dynamic user for containers in Openshift and use NSS_WRAPPER to set it.
NSS_WRAPPER configured. Now running diagnostic commands to reveal nss_wrapper operating as expected.
id:uid=1013040000(indy) gid=0(root) groups=0(root),1013040000
whoami:indy
Loading logging config from: /opt/indy/etc/indy/logging
```

 This shows the process has started and can query the container environment about the running user.
 This integration works for the process.

Note however a remote shell session will still require running the same script. Before java tooling fully works. That is because the remote shell connects using a no-login shell.

```
$ oc -n some-project rsh xxxxxx-49-wvhvs
sh-4.2$ whoami
whoami: cannot find name for user ID 1013040000
sh-4.2$ jps
21 JaxRsBooter
sh-4.2$ source /usr/local/bin/setup-user.sh
Generate passwd file based on dynamic user for containers in Openshift and use NSS_WRAPPER to set it.
NSS_WRAPPER configured. Now running diagnostic commands to reveal nss_wrapper operating as expected.
id:uid=1013040000(indy) gid=0(root) groups=0(root),1013040000
whoami:indy
sh-4.2$ whoami
indy
sh-4.2$ jps
8018 Jps
21 JaxRsBooter
sh-4.2$ 
```

 Notice the additional output for jps. This shows the jps tool itself needs to query the kernel what user is running.