### PR TITLE
Remove copy promotion rules/rule-sets in start-indy.py

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -16,9 +16,9 @@ RUN	tar -zxf /tmp/indy-launcher.tar.gz -C /opt
 
 ADD $data_tarball_url /tmp/indy-launcher-data.tar.gz
 RUN	mkdir -p /usr/share/indy /home/indy && \
-	tar -zxf /tmp/indy-launcher-data.tar.gz -C /usr/share/indy && \
-	mkdir -p /opt/indy/var/lib/indy/data/promote && \
-	cp -rf /usr/share/indy/data/promote/rules /opt/indy/var/lib/indy/data/promote/rules
+	tar -zxf /tmp/indy-launcher-data.tar.gz -C /usr/share/indy
+	# mkdir -p /opt/indy/var/lib/indy/data/promote && \
+	# cp -rf /usr/share/indy/data/promote/rules /opt/indy/var/lib/indy/data/promote/rules
 
 RUN chmod +x /usr/local/bin/*
 

--- a/indy/start-indy.py
+++ b/indy/start-indy.py
@@ -198,8 +198,8 @@ if os.path.isdir(INDY_DATA_PROMOTE):
 
 # copy_over("/usr/share/indy/promote", INDY_DATA_PROMOTE)
 # copy_over("/usr/share/indy/scripts", os.path.join(INDY_DATA, "scripts"))
-copy_missed("/opt/indy/etc/indy/promote", INDY_DATA_PROMOTE)
-copy_missed("/usr/share/indy/data/promote/rules", os.path.join(INDY_DATA_PROMOTE, "rules"))
+# copy_missed("/opt/indy/etc/indy/promote", INDY_DATA_PROMOTE)
+# copy_missed("/usr/share/indy/data/promote/rules", os.path.join(INDY_DATA_PROMOTE, "rules"))
 copy_over("/opt/indy/etc/indy/scripts", os.path.join(INDY_DATA, "scripts"))
 copy_over("/opt/indy/etc/indy/lifecycle", os.path.join(INDY_DATA, "lifecycle"))
 


### PR DESCRIPTION
  As our current promotion rules/rule-sets are managed by configmap, I
  don't think we need to copy from existed ones to overwrite them.