### PR TITLE
Revert "Fix .gitignore permission problem of folo init lifecycle"

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -16,8 +16,8 @@ RUN	tar -zxf /tmp/indy-launcher.tar.gz -C /opt
 
 ADD $data_tarball_url /tmp/indy-launcher-data.tar.gz
 RUN	mkdir -p /usr/share/indy /home/indy && \
-	tar -zxf /tmp/indy-launcher-data.tar.gz -C /usr/share/indy && \
-	mkdir -p /opt/indy/var/lib/indy/data
+	tar -zxf /tmp/indy-launcher-data.tar.gz -C /usr/share/indy
+	# mkdir -p /opt/indy/var/lib/indy/data/promote && \
 	# cp -rf /usr/share/indy/data/promote/rules /opt/indy/var/lib/indy/data/promote/rules
 
 RUN chmod +x /usr/local/bin/*
@@ -27,9 +27,7 @@ RUN chmod +x /usr/local/bin/*
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["bash", "-c", "source /usr/local/bin/setup-user.sh && /usr/local/bin/start-indy.py"]
 
-RUN mkdir -p /etc/indy && \
-    mkdir -p /var/log/indy && \
-    mkdir -p /usr/share/indy /opt/indy/var/log/indy
+RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy /opt/indy/var/log/indy
 RUN chmod -R 777 /etc/indy && chmod -R 777 /var/log/indy && chmod -R 777 /usr/share/indy
 RUN yum remove -y java-1.8.0-openjdk java-1.8.0-openjdk-headless && \
     wget -P /tmp http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7 && \


### PR DESCRIPTION
This reverts commit cd3cd71135aeab52a64b2407f30e11804c904b52 as .gitignore problem fixed in https://github.com/Commonjava/indy/pull/1760