### PR TITLE
Remove -l option when start indy via bash

### DIFF
--- a/indy/start-indy.py
+++ b/indy/start-indy.py
@@ -205,7 +205,7 @@ copy_over("/opt/indy/etc/indy/lifecycle", os.path.join(INDY_DATA, "lifecycle"))
 
 # copy_missed(BACKUP_PROMOTE, INDY_DATA_PROMOTE)
 
-cmd_parts = ["/bin/bash", "-l", os.path.join(INDY_DIR, 'bin', 'indy.sh')]
+cmd_parts = ["/bin/bash", os.path.join(INDY_DIR, 'bin', 'indy.sh')]
 cmd_parts += shlex.split(opts)
 
 print "Command parts: %s" % cmd_parts


### PR DESCRIPTION
Wenjie and I found the envar like HOSTNAME and HOST are not populated to Indy. The symptom is DefaultIndyConfiguration.getDefaultNodeId() always return "localhost" where it should read envar HOSTNAME. 
This breaks sth like honeycomb field node.id which is supposed to be the pod name but now it is always "localhost".

I did a test on indy-perf, mimic the indy startup scenario. 

> sh-4.2$ pwd
> /tmp
> sh-4.2$ cat Test.java 
> public class Test
> {
>     public static void main( String[] args )
>     {
>         System.out.println( "host=" + System.getenv( "HOSTNAME" ) );
>     }
> }
> sh-4.2$ cat test.sh 
> #!/bin/bash
> exec java Test
> sh-4.2$ bash ./test.sh 
> host=ocp4-grxr2-worker-tkwzx
> sh-4.2$ bash -l ./test.sh 
> host=
> 

As you can see, if using the "-l" option, envars are empty. Unfortunately this flag is used in start-indy.py
I don't know exactly why but if this option has no specific purpose we can just remove it.