### PR TITLE
Fix the netty-transport-native-epoll warning

### DIFF
--- a/pathmap-storage-service/start-service.sh
+++ b/pathmap-storage-service/start-service.sh
@@ -6,4 +6,4 @@ export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 export JAVA_CMD=$JAVA_HOME/bin/java
 
 cd /opt/pathmap-storage-service/
-$JAVA_CMD $JAVA_OPTS -jar ./pathmap-storage-service-runner.jar
+$JAVA_CMD $JAVA_OPTS -Dcom.datastax.driver.FORCE_NIO=true  -jar ./pathmap-storage-service-runner.jar


### PR DESCRIPTION
Another way to fix the warning is to add the following dependency:
```
<dependency>
  <groupId>io.netty</groupId>
  <artifactId>netty-transport-native-epoll</artifactId>
  <version>${netty.version}</version>
  <classifier>linux-x86_64</classifier>
</dependency>
```