### PR TITLE
Masked file version from Byteman artifact.

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -34,7 +34,8 @@ RUN yum remove -y java-1.8.0-openjdk java-1.8.0-openjdk-headless && \
     rpm --import /tmp/RPM-GPG-KEY-CentOS-7 && \
     yum-config-manager --add-repo http://mirror.centos.org/centos/7/os/x86_64/ && \
     yum install -y java-11-openjdk-devel.x86_64 gettext
-RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui
+RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui \
+    cp /opt/indy/lib/thirdparty/byteman-* /opt/indy/lib/thirdparty/byteman.jar
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum install -y nss_wrapper && \
     yum clean all && rm -rf /var/cache/yum /tmp/yum.log /tmp/RPM-GPG-KEY-CentOS-7


### PR DESCRIPTION
Copy Byteman file to same location without the version information.
This allows the library to be referenced in a javaagent path without failing the whole JVM startup.