### PR TITLE
Masked the version from Byteman file. Add Byteman script.

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -34,12 +34,14 @@ RUN yum remove -y java-1.8.0-openjdk java-1.8.0-openjdk-headless && \
     rpm --import /tmp/RPM-GPG-KEY-CentOS-7 && \
     yum-config-manager --add-repo http://mirror.centos.org/centos/7/os/x86_64/ && \
     yum install -y java-11-openjdk-devel.x86_64 gettext
-RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui
+RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui \
+    cp /opt/indy/lib/thirdparty/byteman-* /opt/indy/lib/thirdparty/byteman.jar
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum install -y nss_wrapper && \
     yum clean all && rm -rf /var/cache/yum /tmp/yum.log /tmp/RPM-GPG-KEY-CentOS-7
 
 ADD lowOverhead.jfc /usr/share/indy/flightrecorder.jfc
+ADD SetStatement300SecondTimeout.btm /usr/share/indy/
 
 # NCL-4814: set umask to 002 so that group permission is 'rwx'
 # It works because in start-indy.py we invoke indy.sh with bash -l (login shell)

--- a/indy/SetStatement300SecondTimeout.btm
+++ b/indy/SetStatement300SecondTimeout.btm
@@ -1,0 +1,25 @@
+# Rules to set a timeout on a Statement reference
+
+RULE Timeout set during Connection.createStatement 
+INTERFACE java.sql.Connection
+METHOD createStatement
+AT RETURN
+IF TRUE
+DO System.out.println("BYTEMAN:set 300s timeout during createStatement");$!.setQueryTimeout(300)
+ENDRULE
+
+RULE Timeout set during Connection.prepareCall
+INTERFACE java.sql.Connection
+METHOD prepareCall
+AT RETURN
+IF TRUE
+DO System.out.println("BYTEMAN:set 300s timeout during prepareCall");$!.setQueryTimeout(300)
+ENDRULE
+
+RULE Timeout set during Connection.prepareStatement
+INTERFACE java.sql.Connection
+METHOD prepareStatement
+AT RETURN
+IF TRUE
+DO System.out.println("BYTEMAN:set 300s timeout during prepareStatement");$!.setQueryTimeout(300)
+ENDRULE


### PR DESCRIPTION
 This PR masks the version from the filename. To make starting the javaagent succeed at JVM startup.
 Add a Byteman script to the container. So the javaagent can run with this script at JVM boot.
 The Byteman script is used to set a time-out on any java.sql.Statement concrete types that are created by a j.s.Connection.
 This is for the JDK 11 container variant.