### PR TITLE
Fix confusing message

### DIFF
--- a/indy/start-indy.py
+++ b/indy/start-indy.py
@@ -66,7 +66,7 @@ def copy_over(src, target):
     return
   
   if os.path.exists(target):
-    print "rm -r %s %s" % (src, target)
+    print "rm -r %s" % target
     shutil.rmtree(target)
 
   print "cp -r %s %s" % (src, target)


### PR DESCRIPTION
There is an confusing message about the "rm" command. Actually we only remove the target.