### PR TITLE
[gateway] yum install jdk11 from centos

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -2,7 +2,12 @@ FROM quay.io/factory2/nos-java-base:latest
 
 USER root
 
-RUN yum -y install java-11-openjdk-devel
+#RUN yum -y install java-11-openjdk-devel
+RUN yum remove -y java-1.8.0-openjdk java-1.8.0-openjdk-headless && \
+    wget -P /tmp http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7 && \
+    rpm --import /tmp/RPM-GPG-KEY-CentOS-7 && \
+    yum-config-manager --add-repo http://mirror.centos.org/centos/7/os/x86_64/ && \
+    yum -y install java-11-openjdk-devel.x86_64
 
 RUN mkdir -p /deployment/log && \
   chmod -R 777 /deployment/log && \


### PR DESCRIPTION
I hit subscription issue on gateway img build. It says: error building at STEP "RUN yum -y install java-11-openjdk-devel". Indy use jdk11 from centos so Iet's try this.