### PR TITLE
Update origin-jenkins-agent-base to 4.10

### DIFF
--- a/spmm-jenkins-agent-go/Dockerfile
+++ b/spmm-jenkins-agent-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-jenkins-agent-base:v4.0
+FROM quay.io/openshift/origin-jenkins-agent-base:4.10
 
 LABEL maintainer="RedHat EXD SPMM TEAM"
 


### PR DESCRIPTION
All daily jobs fail after Jenkins upgrade. The error says:
spmm-automation/jenkins-slave-767d527a-028c-414b-a0c7-8b4a845968a6-jblg8-x5vrl Container jnlp was terminated (Exit Code: 1, Reason: Error)

I highly suspect this is because the version mismatch between master and slaves. The pr update the version to 4.10, same to Jenkins master version.
ref https://quay.io/repository/openshift/origin-jenkins-agent-base?tab=tags