### PR TITLE
Update nos-java-base images

### DIFF
--- a/nos-java-base/Dockerfile.jdk11
+++ b/nos-java-base/Dockerfile.jdk11
@@ -1,0 +1,36 @@
+# Uncomment this for community builds
+#FROM quay.io/centos/centos:centos7
+
+# Change base image to use ubi7
+FROM registry.access.redhat.com/ubi7:7.9
+
+LABEL io.openshift.sti.scripts-url="image:///usr/local/sti" \
+    io.openshift.s2i.scripts-url="image:///usr/local/sti" \
+    Component="nos-sti-base" \
+    Name="nos-java-base" \
+    Version="8" \
+    Release="1" \
+    maintainer="RedHat SPMM Team <nos-devel@redhat.com>"
+
+USER root
+
+ENV TZ UTC
+
+ADD RH-IT-Root-CA.crt /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
+ADD 2022-IT-Root-CA.pem /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
+RUN update-ca-trust extract
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/local/bin/dumb-init
+
+RUN yum -y update && \
+    yum -y install wget git tar which curl tree java-11-openjdk-devel net-tools lsof iotop && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+ADD start.sh /usr/local/bin/start.sh
+
+RUN chmod +x /usr/local/bin/*
+
+USER 1001
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/start.sh"]


### PR DESCRIPTION
 * Add new nos-base image which does not contain jdk installation
 * Add new jdk8 and jdk11 base image which refer nos-base with specified java version installation