### PR TITLE
[metadata service] fix the deployment path

### DIFF
--- a/indy-metadata-service/actions.Dockerfile
+++ b/indy-metadata-service/actions.Dockerfile
@@ -8,20 +8,20 @@ ADD start-service.sh /usr/local/bin/start-service.sh
 
 RUN chmod +x /usr/local/bin/*
 
-RUN mkdir -p /opt/indy-metadata-service/log && \
-  chmod -R 777 /opt/indy-metadata-service && \
-  chmod -R 777 /opt/indy-metadata-service/log
+RUN mkdir -p /deployment/log && \
+  chmod -R 777 /deployment && \
+  chmod -R 777 /deployment/log
 
-ADD indy-metadata-service-runner.jar /opt/indy-metadata-service/indy-metadata-service-runner.jar
-RUN chmod +r /opt/indy-metadata-service/indy-metadata-service-runner.jar
+ADD indy-metadata-service-runner.jar /deployment/indy-metadata-service-runner.jar
+RUN chmod +r /deployment/indy-metadata-service-runner.jar
 
 # Run as non-root user
 RUN chgrp -R 0 /opt && \
     chmod -R g=u /opt && \
-    chgrp -R 0 /opt/indy-metadata-service && \
-    chmod -R g=u /opt/indy-metadata-service && \
-    chgrp -R 0 /opt/indy-metadata-service/log && \
-    chmod -R g=u /opt/indy-metadata-service/log
+    chgrp -R 0 /deployment && \
+    chmod -R g=u /deployment && \
+    chgrp -R 0 /deployment/log && \
+    chmod -R g=u /deployment/log
 
 USER 1001
 


### PR DESCRIPTION
As it uses '/deployment' instead of '/opt/xxx'. 