### PR TITLE
Fix NSS_WRAPPER setup for OpenShift dynamic users

### DIFF
--- a/indy/Dockerfile
+++ b/indy/Dockerfile
@@ -32,7 +32,7 @@ CMD ["bash", "-c", "source /usr/local/bin/setup-user.sh && /usr/local/bin/start-
 RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy /opt/indy/var/log/indy
 RUN chmod -R 777 /etc/indy && chmod -R 777 /var/log/indy && chmod -R 777 /usr/share/indy
 RUN yum remove -y java-1.8.0-openjdk java-1.8.0-openjdk-headless && \
-    yum install -y java-11-openjdk-devel.x86_64 gettext unzip
+    yum install -y java-11-openjdk-devel.x86_64 gettext unzip nss_wrapper
 RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui
 RUN yum clean all && rm -rf /var/cache/yum /tmp/yum.log /tmp/RPM-GPG-KEY-CentOS-7 && \
     wget --quiet -O /tmp/byteman.zip https://downloads.jboss.org/byteman/4.0.14/byteman-download-4.0.14-bin.zip && \

--- a/indy/actions.Dockerfile
+++ b/indy/actions.Dockerfile
@@ -30,7 +30,7 @@ CMD ["bash", "-c", "source /usr/local/bin/setup-user.sh && /usr/local/bin/start-
 RUN mkdir -p /etc/indy && mkdir -p /var/log/indy && mkdir -p /usr/share/indy /opt/indy/var/log/indy
 RUN chmod -R 777 /etc/indy && chmod -R 777 /var/log/indy && chmod -R 777 /usr/share/indy
 RUN yum remove -y java-1.8.0-openjdk java-1.8.0-openjdk-headless && \
-    yum install -y java-11-openjdk-devel.x86_64 gettext unzip
+    yum install -y java-11-openjdk-devel.x86_64 gettext unzip nss_wrapper
 RUN cp -rf /opt/indy/var/lib/indy/ui /usr/share/indy/ui
 RUN yum clean all && rm -rf /var/cache/yum /tmp/yum.log /tmp/RPM-GPG-KEY-CentOS-7 && \
     wget --quiet -O /tmp/byteman.zip https://downloads.jboss.org/byteman/4.0.14/byteman-download-4.0.14-bin.zip && \

--- a/indy/setup-user.sh
+++ b/indy/setup-user.sh
@@ -3,10 +3,17 @@ echo "Generate passwd file based on dynamic user for containers in Openshift and
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 envsubst < /opt/passwd.template > $HOME/passwd
-chmod 744 $HOME/passwd
-export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
-export NSS_WRAPPER_PASSWD=$HOME/passwd
-export NSS_WRAPPER_GROUP=/etc/group
-echo "NSS_WRAPPER configured. Now running diagnostic commands to reveal nss_wrapper operating as expected."
-echo "id:$(id)"
-echo "whoami:$(whoami)"
+chmod 644 $HOME/passwd
+
+# Only configure NSS_WRAPPER if the library exists
+if [ -f /usr/lib64/libnss_wrapper.so ]; then
+    export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+    export NSS_WRAPPER_PASSWD=$HOME/passwd
+    export NSS_WRAPPER_GROUP=/etc/group
+    echo "NSS_WRAPPER configured. Now running diagnostic commands to reveal nss_wrapper operating as expected."
+    echo "id:$(id)"
+    echo "whoami:$(whoami)"
+else
+    echo "WARNING: nss_wrapper.so not found at /usr/lib64/libnss_wrapper.so - NSS_WRAPPER not configured"
+    echo "id:$(id)"
+fi


### PR DESCRIPTION
This is for fixing [MMENG-4500](https://issues.redhat.com/browse/MMENG-4500)
Indy boot - object '/usr/lib64/libnss_wrapper.so' from LD_PRELOAD cannot be preloaded
---
- Install nss_wrapper package in both Dockerfile and actions.Dockerfile
- Add error checking in setup-user.sh to verify library exists before preload
- Improve passwd file permissions (644 instead of 744)
- Add diagnostic output to help troubleshoot NSS_WRAPPER issues

This resolves the "ld.so: object '/usr/lib64/libnss_wrapper.so' from LD_PRELOAD cannot be preloaded" error that occurs when containers run with arbitrary UIDs in OpenShift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)